### PR TITLE
Implement model management and migration endpoints

### DIFF
--- a/backend/src/dbMigration/initDb.sql
+++ b/backend/src/dbMigration/initDb.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    companyName TEXT NOT NULL,
+    jobTitle TEXT NOT NULL,
+    jobDescription TEXT NOT NULL,
+    jobUrl TEXT,
+    jobStatus TEXT NOT NULL,
+    jobSource TEXT,
+    jobType TEXT,
+    jobLocation TEXT,
+    jobSalary TEXT,
+    jobContact TEXT,
+    jobNotes TEXT,
+    jobDateApplied TEXT,
+    jobDateCreated TEXT NOT NULL,
+    jobDateUpdated TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS resumes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resumeName TEXT NOT NULL,
+    resumeContent TEXT NOT NULL,
+    dateCreated TEXT NOT NULL,
+    dateUpdated TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mainResumes (
+    id INTEGER PRIMARY KEY,
+    resumeName TEXT NOT NULL,
+    resumeContent TEXT NOT NULL,
+    dateCreated TEXT NOT NULL,
+    dateUpdated TEXT NOT NULL
+);

--- a/backend/src/dbMigration/initDb.ts
+++ b/backend/src/dbMigration/initDb.ts
@@ -1,0 +1,35 @@
+export default `
+CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    companyName TEXT NOT NULL,
+    jobTitle TEXT NOT NULL,
+    jobDescription TEXT NOT NULL,
+    jobUrl TEXT,
+    jobStatus TEXT NOT NULL,
+    jobSource TEXT,
+    jobType TEXT,
+    jobLocation TEXT,
+    jobSalary TEXT,
+    jobContact TEXT,
+    jobNotes TEXT,
+    jobDateApplied TEXT,
+    jobDateCreated TEXT NOT NULL,
+    jobDateUpdated TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS resumes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resumeName TEXT NOT NULL,
+    resumeContent TEXT NOT NULL,
+    dateCreated TEXT NOT NULL,
+    dateUpdated TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mainResumes (
+    id INTEGER PRIMARY KEY,
+    resumeName TEXT NOT NULL,
+    resumeContent TEXT NOT NULL,
+    dateCreated TEXT NOT NULL,
+    dateUpdated TEXT NOT NULL
+);
+`;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import {JobService} from './job/jobService'
 import {MainResumeService} from './mainResume/mainResumeService'
 import {ResumeService} from './resume/resumeService'
 import {generateJsonFromResume, inferJobDescription, checkCompatiblity, generateResume, inferCompanyDetails, inferJobDescriptionFromUrl, listAvailableModels, setPreferredModel} from './openai'
+import initDbSql from './dbMigration/initDb'
 import {AppError} from './types'
 import * as schemas from './schemas'
 
@@ -961,14 +962,7 @@ app.openapi(selectModelRoute, async (c) => {
 
 app.openapi(migrateRoute, async (c) => {
         try {
-                let module
-                try {
-                        module = await import('./dbMigration/initDb')
-                } catch (_) {
-                        return c.json({error: 'initDb script not found'}, 404)
-                }
-                const sql = module.default as string
-                const statements = sql.split(';').map((s) => s.trim()).filter(Boolean)
+                const statements = initDbSql.split(';').map((s) => s.trim()).filter(Boolean)
                 for (const stmt of statements) {
                         await c.env.DB.exec(stmt)
                 }
@@ -984,7 +978,7 @@ app.openapi(migrateWithParamsRoute, async (c) => {
                 const {toVersion} = c.req.valid('param')
                 let module
                 try {
-                        module = await import(`./dbMigration/v${toVersion}.js`)
+                        module = await import(`./dbMigration/v${toVersion}.ts`)
                 } catch (_) {
                         return c.json({error: 'migration script not found'}, 404)
                 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -996,18 +996,18 @@ app.openapi(migrateWithParamsRoute, async (c) => {
 
 // OpenAPI documentation endpoints
 app.get('/doc', c => c.json({
-	openapi: '3.0.0',
-	info: {
-		version: '1.0.0',
-		title: 'Jobjigsaw API',
-		description: 'AI-powered job application and resume customization platform API'
-	},
-	servers: [
-		{
-			url: 'http://localhost:8787',
-			description: 'Development server'
-		}
-	],
+        openapi: '3.0.0',
+        info: {
+                version: '1.0.0',
+                title: 'Jobjigsaw API',
+                description: 'AI-powered job application and resume customization platform API'
+        },
+        servers: [
+                {
+                        url: new URL(c.req.url).origin,
+                        description: 'Current server'
+                }
+        ],
 	tags: [
 		{ name: 'Jobs', description: 'Job management and analysis' },
 		{ name: 'Main Resume', description: 'User\'s main resume management' },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -968,7 +968,10 @@ app.openapi(migrateRoute, async (c) => {
                         return c.json({error: 'initDb script not found'}, 404)
                 }
                 const sql = module.default as string
-                await c.env.DB.exec(sql)
+                const statements = sql.split(';').map((s) => s.trim()).filter(Boolean)
+                for (const stmt of statements) {
+                        await c.env.DB.exec(stmt)
+                }
                 return c.json({success: true})
         } catch (error: unknown) {
                 const {error: errorMessage, status} = handleError(error, "Error running migration")
@@ -986,7 +989,10 @@ app.openapi(migrateWithParamsRoute, async (c) => {
                         return c.json({error: 'migration script not found'}, 404)
                 }
                 const sql = module.default as string
-                await c.env.DB.exec(sql)
+                const statements = sql.split(';').map((s) => s.trim()).filter(Boolean)
+                for (const stmt of statements) {
+                        await c.env.DB.exec(stmt)
+                }
                 return c.json({success: true})
         } catch (error: unknown) {
                 const {error: errorMessage, status} = handleError(error, "Error running migration")
@@ -1520,7 +1526,7 @@ app.get('/doc', c => c.json({
                                                                                         type: 'array',
                                                                                         items: {
                                                                                                 type: 'object',
-                                                                                                properties: { id: { type: 'string' }, provider: { type: 'string' } }
+                                                                                                properties: { id: { type: 'string' }, name: { type: 'string' }, provider: { type: 'string' } }
                                                                                         }
                                                                                 }
                                                                         }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -961,7 +961,13 @@ app.openapi(selectModelRoute, async (c) => {
 
 app.openapi(migrateRoute, async (c) => {
         try {
-                const sql = (await import('./dbMigration/initDb.sql?raw')).default
+                let module
+                try {
+                        module = await import('./dbMigration/initDb')
+                } catch (_) {
+                        return c.json({error: 'initDb script not found'}, 404)
+                }
+                const sql = module.default as string
                 await c.env.DB.exec(sql)
                 return c.json({success: true})
         } catch (error: unknown) {
@@ -973,7 +979,13 @@ app.openapi(migrateRoute, async (c) => {
 app.openapi(migrateWithParamsRoute, async (c) => {
         try {
                 const {toVersion} = c.req.valid('param')
-                const sql = (await import(`./dbMigration/v${toVersion}.sql?raw`)).default
+                let module
+                try {
+                        module = await import(`./dbMigration/v${toVersion}.js`)
+                } catch (_) {
+                        return c.json({error: 'migration script not found'}, 404)
+                }
+                const sql = module.default as string
                 await c.env.DB.exec(sql)
                 return c.json({success: true})
         } catch (error: unknown) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -962,10 +962,15 @@ app.openapi(selectModelRoute, async (c) => {
 
 app.openapi(migrateRoute, async (c) => {
         try {
-                const statements = initDbSql.split(';').map((s) => s.trim()).filter(Boolean)
-                for (const stmt of statements) {
+        const statements = initDbSql.split(';').map((s) => s.trim()).filter(Boolean)
+        for (const stmt of statements) {
+                try {
                         await c.env.DB.exec(stmt)
+                } catch (err) {
+                        console.error('Migration failed for statement:', stmt)
+                        throw err
                 }
+        }
                 return c.json({success: true})
         } catch (error: unknown) {
                 const {error: errorMessage, status} = handleError(error, "Error running migration")
@@ -983,10 +988,15 @@ app.openapi(migrateWithParamsRoute, async (c) => {
                         return c.json({error: 'migration script not found'}, 404)
                 }
                 const sql = module.default as string
-                const statements = sql.split(';').map((s) => s.trim()).filter(Boolean)
-                for (const stmt of statements) {
+        const statements = sql.split(';').map((s) => s.trim()).filter(Boolean)
+        for (const stmt of statements) {
+                try {
                         await c.env.DB.exec(stmt)
+                } catch (err) {
+                        console.error('Migration failed for statement:', stmt)
+                        throw err
                 }
+        }
                 return c.json({success: true})
         } catch (error: unknown) {
                 const {error: errorMessage, status} = handleError(error, "Error running migration")

--- a/backend/src/openai.ts
+++ b/backend/src/openai.ts
@@ -315,8 +315,8 @@ export async function listAvailableModels(env: Env) {
     const openaiModels = await env.JOBJIBSAW.models({provider: 'openai'})
     const geminiModels = await env.JOBJIBSAW.models({provider: 'google-ai-studio'})
     return [
-        ...openaiModels.map((m: any) => ({id: m.id, provider: 'openai'})),
-        ...geminiModels.map((m: any) => ({id: m.id, provider: 'google-ai-studio'})),
+        ...openaiModels.map((m: any) => ({id: m.id, name: m.name || m.id, provider: 'openai'})),
+        ...geminiModels.map((m: any) => ({id: m.id, name: m.name || m.id, provider: 'google-ai-studio'})),
     ]
 }
 

--- a/backend/src/openai.ts
+++ b/backend/src/openai.ts
@@ -310,3 +310,19 @@ export async function inferCompanyDetails(companyName: string, env: Env) {
         return response.text()
     }
 }
+
+export async function listAvailableModels(env: Env) {
+    const openaiModels = await env.JOBJIBSAW.models({provider: 'openai'})
+    const geminiModels = await env.JOBJIBSAW.models({provider: 'google-ai-studio'})
+    return [
+        ...openaiModels.map((m: any) => ({id: m.id, provider: 'openai'})),
+        ...geminiModels.map((m: any) => ({id: m.id, provider: 'google-ai-studio'})),
+    ]
+}
+
+export async function setPreferredModel(modelName: string, provider: string, env: Env) {
+    const useOpenAi = provider === 'openai'
+    await env.AI_GATEWAY_KV.put('PREFERRED_MODEL', JSON.stringify({preferredModel: modelName, useOpenAi}))
+}
+
+export { getModel }

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -41,6 +41,25 @@ export const JobAnalyzeSchema = z.object({
     jobUrl: z.string().url().openapi({ example: 'https://jobs.example.com/software-engineer' })
 }).openapi('JobAnalyze')
 
+export const ModelInfoSchema = z.object({
+    id: z.string().openapi({example: 'gpt-4o'}),
+    provider: z.string().openapi({example: 'openai'})
+}).openapi('ModelInfo')
+
+export const ModelsResponseSchema = z.object({
+    models: ModelInfoSchema.array()
+}).openapi('ModelsResponse')
+
+export const SelectModelSchema = z.object({
+    modelName: z.string().openapi({example: 'gpt-4o'}),
+    provider: z.string().openapi({example: 'openai'})
+}).openapi('SelectModel')
+
+export const MigrateParamsSchema = z.object({
+    fromVersion: z.string().openapi({param: {name:'fromVersion', in:'path'}, example:'0'}),
+    toVersion: z.string().openapi({param: {name:'toVersion', in:'path'}, example:'1'})
+})
+
 // Resume schemas
 export const ResumeSchema = z.object({
     id: z.number().optional().openapi({ example: 1 }),

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -43,6 +43,7 @@ export const JobAnalyzeSchema = z.object({
 
 export const ModelInfoSchema = z.object({
     id: z.string().openapi({example: 'gpt-4o'}),
+    name: z.string().openapi({example: 'GPT-4o'}),
     provider: z.string().openapi({example: 'openai'})
 }).openapi('ModelInfo')
 

--- a/backend/src/utils/cloudflareKv.ts
+++ b/backend/src/utils/cloudflareKv.ts
@@ -7,12 +7,17 @@ export class CloudflareKv {
         this.kv = kv;
     }
 
-    async put(key: string, value: string) {
-        return this.kv.put(key, value);
+    async put(key: string, value: string, options?: {expirationTtl?: number}) {
+        return this.kv.put(key, value, options);
     }
 
     async get(key: string) {
         return this.kv.get(key);
+    }
+
+    async list(prefix?: string) {
+        const res = await this.kv.list({prefix});
+        return res.keys.map((k) => k.name);
     }
 
     async delete(key: string) {


### PR DESCRIPTION
## Summary
- extend KV utility with TTL put and list
- support listing and setting AI models
- add DB migration endpoint with init script
- cache inferred jobs & matches
- surface cached jobs in job list
- expose root Hello World route
- document new APIs in Swagger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875fac3e834832c848d1f094a0ed7e0